### PR TITLE
display Document::path() in the docs

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -42,7 +42,6 @@ impl Document {
         self.doc_path.document_id()
     }
 
-    #[doc(hidden)]
     pub fn path(&self) -> &DocumentPath {
         &self.doc_path
     }


### PR DESCRIPTION
ref #42

I'm pretty sure this isn't intended, considering `id()` will be removed in the future.